### PR TITLE
Fixed issue preventing valve setting from being effectively changed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ temp.rpt
 examples/*.inp
 wntr/tests/*.png
 wntr/tests/performance_results
+examples/signal.csv
+examples/temp.hyd

--- a/documentation/controls.rst
+++ b/documentation/controls.rst
@@ -26,9 +26,9 @@ WNTR includes additional options to define controls and rules that can be used b
 
 The basic steps to define a control or rule are:
 
-1. Define the action(s)
-2. Define condition(s) (i.e., define what should cause the action to occur)
-3. Define the control or rule using the action(s) and condition(s)
+1. Define the action(s) (i.e., define the action that should occur, such as closing/opening a link)
+2. Define condition(s) (i.e., define what should cause the action to occur, such as a tank level)
+3. Define the control or rule using the action(s) and condition(s) (i.e., combine the defined action and condition)
 4. Add the control or rule to the water network model
 
 These steps are defined below.  

--- a/documentation/disaster_models.rst
+++ b/documentation/disaster_models.rst
@@ -211,7 +211,7 @@ highlight the need to minimize human health and economic impacts.
 WNTR simulates contamination incidents by introducing contaminants into the distribution system and allowing them to propagate through the system. 
 The section on :ref:`water_quality_simulation` includes steps to define and simulate contamination incidents.
 
-Future versions of WNTR will be able to simulate changes in source water quality due to disruptions.
+Future versions of WNTR will be able to simulate changes in source water quality due to contamination incidents.
 
 Other disaster scenarios
 -------------------------------

--- a/documentation/getting_started.rst
+++ b/documentation/getting_started.rst
@@ -9,7 +9,7 @@ To start using WNTR, open a Python console and import the package::
 
 	import wntr	
 
-WNTR comes with a simple `getting started example <https://github.com/USEPA/WNTR/blob/master/examples/getting_started.py>`_, shown below.
+WNTR comes with a simple `getting started example <https://github.com/USEPA/WNTR/blob/master/examples/getting_started.py>`_, shown below that uses EPANET Example Network 3 (Net3).
 This example demonstrates how to:
 
 * Import WNTR
@@ -19,7 +19,9 @@ This example demonstrates how to:
 
 .. literalinclude:: ../examples/getting_started.py
 
-Additional examples are included throughout the WNTR documentation.
+Additional examples are included throughout the WNTR documentation. The examples provided in the documentation assume
+that a user has experience using EPANET (https://www.epa.gov/water-research/epanet) and Python (https://www.python.org/), including the ability to install and use additional Python packages, such as those listed in :ref:`requirements` and :ref:`optional_dependencies`.
+
 
 Several EPANET INP files and example files are also included in the WNTR repository in the `examples folder <https://github.com/USEPA/WNTR/blob/master/examples>`_.
 Example networks range from a simple 9 node network to a 3,000 node network.

--- a/documentation/graphics.rst
+++ b/documentation/graphics.rst
@@ -105,8 +105,8 @@ As with basic network graphics, a wide range of plotting options can be supplied
 .. note:: 
    This function requires the Python package **folium**, which is an optional dependency of WNTR.
    
-The following example converts node coordinates to longitude/latitude and plots the network along 
-with pipe length over the city of Albuquerque (for demonstration purposes only) (:numref:`fig-leaflet`).
+The following example using EPANET Example Network 3 (Net3) converts node coordinates to longitude/latitude and plots the network along 
+with pipe length over the city of Albuquerque (for demonstration purposes only) (:numref:`fig-leaflet`). The longitude and latitude for two locations are needed to plot the network. For the EPANET Example Network 3, these locations are the reservoir 'Lake' and node '219'.  
 
 .. doctest::
 

--- a/documentation/hydraulics.rst
+++ b/documentation/hydraulics.rst
@@ -217,8 +217,8 @@ Newton-Raphson algorithm.
 :numref:`fig-pressure-dependent` illustrates the pressure-demand relationship using both the demand-driven and pressure dependent demand simulations.
 In the example, 
 :math:`D_f` is 0.0025 m³/s (39.6 GPM),
-:math:`P_f` is 30 psi, and 
-:math:`P_0` is 5 psi.
+:math:`P_f` is 30 psi (21.097 m), and 
+:math:`P_0` is 5 psi (3.516 m).
 Using the demand-driven simulation, the demand is equal to :math:`D_f` regardless of pressure.  
 Using the pressure dependent demand simulation, the demand starts to decrease when the pressure is below :math:`P_f` and goes to 0 when pressure is below :math:`P_0`.
 
@@ -344,7 +344,8 @@ To restart the simulation from time zero, the user has several options.
        >>> results = sim.run_sim()
     
 If these options do not cover user specific needs, then the water network
-model would need to be recreated between simulations or reset by hand.
+model would need to be recreated between simulations or reset manually by changing individual attributes to the desired
+values.
 Note that when using the EpanetSimulator, the model is reset each time it is used in 
 a simulation.
 

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -168,7 +168,7 @@ Detailed installation instructions are included below.
 Requirements
 -------------
 Requirements for WNTR include 64-bit Python (tested on versions 3.6 and 3.7) along with several Python packages. 
-The following Python packages are required:
+Users should have experience using Python (https://www.python.org/), including the installation of additional Python packages. The following Python packages are required:
 
 * NumPy [VaCV11]_: used to support large, multi-dimensional arrays and matrices, 
   http://www.numpy.org/

--- a/documentation/overview.rst
+++ b/documentation/overview.rst
@@ -36,7 +36,9 @@ package designed to simulate and analyze resilience of water distribution networ
 Here, a network refers to the collection of pipes, pumps, valves, junctions, tanks, and reservoirs that 
 make up a water distribution system. WNTR has an application programming interface (API) 
 that is flexible and allows for changes to the network structure and operations, 
-along with simulation of disruptive incidents and recovery actions.  
+along with simulation of disruptive incidents and recovery actions. WNTR is based upon EPANET, which is a tool to simulate the movement and fate of drinking water constituents within distribution systems. Users are encouraged to be familiar with the use of
+EPANET and/or should have background knowledge in hydraulics and pressurized pipe network modeling before using WNTR. EPANET has a graphical user interface that might be a useful tool to facilitate the visualization of the network and the associated analysis results. Information on EPANET can be found at https://www.epa.gov/water-research/epanet. WNTR is compatible with EPANET 2.00.12 [Ross00]_. In addition, users should have experience using Python, including the installation of additional Python packages. General information on Python can be found at https://www.python.org/. 
+
 WNTR can be installed through the United States Environmental Protection Agency (US EPA) 
 GitHub organization at https://github.com/USEPA/WNTR.  An integrated development environment 
 (IDE), like Spyder, is recommended for users and developers.
@@ -56,9 +58,9 @@ WNTR includes capabilities to:
 
 * **Modify network structure** by adding/removing components, changing component characteristics, and using network morphology operations
 
-* **Modify network operation** by changing initial conditions, component settings, and time-based and conditional controls
+* **Modify network operation** by changing initial conditions, component settings, supply and demand, and time-based and conditional controls
 
-* **Add disruptive incidents** including damage to tanks, valves, and pumps, pipe leaks, power outages, contaminant injection, and changes to supply and demand
+* **Add disruptive incidents** including damage to tanks, valves, and pumps, pipe leaks, power outages, contaminant injection, and environmental changes
 
 * **Add response/repair/mitigation strategies** including leak repair, retrofitted pipes, power restoration, and backup generation
 
@@ -91,7 +93,8 @@ These packages allow the user to build custom analysis directly in Python, and g
 analyze the structure of complex water distribution networks, 
 analyze time-series data from simulation results,
 run simulations efficiently, and 
-create high-quality graphics and animations.
+create high-quality graphics and animations.     
+
 
 .. note:: 
   EPANET refers to EPANET 2.00.12 unless otherwise noted. Future releases of WNTR will include EPANET 2.2.0.

--- a/documentation/waternetworkmodel.rst
+++ b/documentation/waternetworkmodel.rst
@@ -257,7 +257,7 @@ Build a model from scratch
 ---------------------------------
 
 A water network model can also be created from scratch by adding elements to an empty model.  Elements 
-must be added before used.  For example, demand patterns are added to the model before they are 
+must be added before they are used in a simulation.  For example, demand patterns are added to the model before they are 
 used within a junction. The section below includes additional information on adding elements to a 
 water network model.
  

--- a/wntr/epanet/io.py
+++ b/wntr/epanet/io.py
@@ -797,17 +797,17 @@ class InpFile(object):
                  'node2': valve.end_node_name,
                  'diam': from_si(self.flow_units, valve.diameter, HydParam.PipeDiameter),
                  'vtype': valve.valve_type,
-                 'set': valve._initial_setting,
+                 'set': valve._setting,
                  'mloss': valve.minor_loss,
                  'com': ';'}
             valve_type = valve.valve_type
             formatter = _VALVE_ENTRY
             if valve_type in ['PRV', 'PSV', 'PBV']:
-                valve_set = from_si(self.flow_units, valve._initial_setting, HydParam.Pressure)
+                valve_set = from_si(self.flow_units, valve._setting, HydParam.Pressure)
             elif valve_type == 'FCV':
-                valve_set = from_si(self.flow_units, valve._initial_setting, HydParam.Flow)
+                valve_set = from_si(self.flow_units, valve._setting, HydParam.Flow)
             elif valve_type == 'TCV':
-                valve_set = valve._initial_setting
+                valve_set = valve._setting
             elif valve_type == 'GPV':
                 valve_set = valve.headloss_curve_name
                 formatter = _GPV_ENTRY


### PR DESCRIPTION
Even after changing a valve setting using the get_pipe method to get a valve and change it, the resulting inp file still had the original setting. Fixed issue by changing io.py. Travis reports all ok (211 tests, skipping 10).

Note: 
The USEPA/WNTR GitHub site, https://github.com/USEPA/WNTR, does not link to Travis CI for continuous integration software testing.  
The core development team uses the sandialabs/WNTR fork, https://github.com/sandialabs/wntr, to run tests.
To submit a Pull Request to USEPA/WNTR, the developer needs to link their fork to Travis so that test results can be inspected.
If the developer does not have Travis linked to their fork, the Pull Request can be submitted to the sandialabs/WNTR fork.

